### PR TITLE
Three fixes for Netmaze - 8 bit texures, betterbot, and sound

### DIFF
--- a/audio.c
+++ b/audio.c
@@ -34,7 +34,7 @@
 #endif
 
 #ifdef HAVE_FLUSH
-/* #include <stropts.h> */
+  #include <stropts.h> 
 #endif
 
 #ifdef SS10_AUDIO
@@ -227,7 +227,11 @@ static int read_data(char *f,int type)
   blen = ftell(fd)-pos;
   fseek(fd,pos,0);
 
-  data = (char *) ((malloc(blen*play_delay+16)+15) & 0xfffffff0);
+  //data = (char *) ((malloc(blen*play_delay+16)+15) & 0xfffffff0);
+  void *memptr = NULL;
+  data = posix_memalign(&memptr, 16, blen*play_delay+16);
+  data = memptr;
+
   fread(data,1,blen,fd);
   fclose(fd);
 

--- a/better.c
+++ b/better.c
@@ -189,6 +189,7 @@ void init_robot(void)
 {
   srand48(258245);
   strcpy(sm->owncomment,"Ich weiss, dass ich besser bin!");
+  strcpy(sm->ownname,"Betterbot");
 }
 
 void start_robot(int num)

--- a/config.h
+++ b/config.h
@@ -10,6 +10,14 @@
 /* #define RS6000 1 */  /* look at CREDITS */
 /* #define NeXT 1   */  /* look at CREDITS */
 
+/* Note USE_SOUND 1 under Linux environments expects the
+*  Open Sound System environment.  Most modern Linux 
+*  distros can provide this under the ALSA environment via 
+*  the AOSS wrapper.
+*  (e.g.  aoss netmaze -options)
+*  See:
+*  https://alsa.opensrc.org/Aoss
+*/ 
 #define USE_SOUND 1
 
 /* set the paths, according to your environment: */
@@ -55,4 +63,3 @@
 #endif
 
 
-#undef USE_SOUND

--- a/texture.c
+++ b/texture.c
@@ -394,11 +394,17 @@ struct texture *load_texture(char *name)
   {
     tex->datatab = malloc( sizeof(char *) * (h+1) );
     texturemem += (h>>1)*w*h+((w*h)>>1)+4;
-    tex->data = (char *) (((int) malloc((h>>1)*w*h+((w*h)>>1)+4) + 3) & 0xfffffffc);
+    //tex->data = (char *) (((int) malloc((h>>1)*w*h+((w*h)>>1)+4) + 3) & 0xfffffffc);
+    void *memptr = NULL;
+    tex->data = posix_memalign(&memptr, 32, (h>>1)*w*h+((w*h)>>1)+4);
+    tex->data = memptr;
   }
   else
   {
-    tex->data = (char *) (((int) malloc(w*h+4) + 3) & 0xfffffffc);
+    //tex->data = (char *) (((int) malloc(w*h+4) + 3) & 0xfffffffc);
+    void *memptr = NULL;
+    tex->data = posix_memalign(&memptr, 32, w*h+4 );
+    tex->data = memptr;
     texturemem += w*h+4;
   }
   if( (tex->data == NULL) || (precalc && (tex->datatab == NULL)) )


### PR DESCRIPTION
Hi again.

This is probably poor practice but I've wrapped three improvements to Netmaze into this single pull request.  I probably should have created separate branches.  Sorry, but I'm lazy :).  Anyhow each commit represent a feature fix.  Obviously you can cherry-pick if you like only parts of it.

I already told you about the first commit, it fixes the textures loading when running under an 8 bit color scheme (I used Xephyr as an XServer to provide that depth).
 
The second commit is small but it got the robot, Betterbot working on my system.  I'm not entirely sure why it worked but I think it is safe.

The third commit got sound working.  However in order to use another tool called aoss is required from the alsa-utils package to wrap the open sound system calls and make them work with ALSA.  (Details are in the comments of audio.c )  

Maybe you could add a recommends/suggests for alsa-utils and xserver-xephyr to the netmaze package?  Probably needs some explanation in the readme as well.  The sound is kind of sketchy at the moment but at least it's entertaining.

Hopefully you find these useful.  I'm doing it mostly for the intellectual stimulation (improving my C skills, etc)  

I was going to use Google translate to convert comments in Betterbot to English - at least the stuff that shows up on the screen.  Also I've got a few poorly written scripts to run all this if you're interested.  They aren't in the Git repo but I can send separately.

Regards,
Craig
